### PR TITLE
KVM

### DIFF
--- a/emulation.c
+++ b/emulation.c
@@ -436,6 +436,9 @@ unsigned int CreateEmulatedThread(uint32_t eip) {
   ctx->eip = eip;
   ctx->esp = esp;
   ctx->ebp = 0;
+  ctx->fpsw = 0x0000;
+  ctx->fpcw = 0x037F;
+  ctx->fptw = 0xFFFF;
   ctx->sleep = 0;
   ctx->terminated = false;
   PrintContext(ctx);


### PR DESCRIPTION
Adds rudimentary KVM support.

In the process, I noticed that `_CIacos` is being used for camera rotations, as having broken FP0 caused the camera to face the wrong way. This also confirms that the existing implementation seems to work.

An issue should be created for fptag being wrong, as this uses an abridged version, meaning that there will be some information loss (unfortunately..).

Partially solves #6 

*(Note that this patch is not yet in OpenSWE1R and should be ported to that as well)*